### PR TITLE
fix: fixed the mail route

### DIFF
--- a/components/Footer/index.js
+++ b/components/Footer/index.js
@@ -44,7 +44,7 @@ export default Footer
 function SocialLink({ url, children }) {
 
   return (
-    <a href={url} target="_blank" className=" no-underline text-white-100 decoration-none hover:text-white-100 mr-4 ">
+    <a href={url.includes("@") ? `mailto:${url}`: url} target="_blank" className=" no-underline text-white-100 decoration-none hover:text-white-100 mr-4 ">
       {children}
     </a>
   )


### PR DESCRIPTION
The footer mail had an issues


instead of redirecting to `mailto:hello@website.com` it redirects to `https://www.website.com/hello@website.com`